### PR TITLE
Add support for function-bind operator e.g. func::bind(this)

### DIFF
--- a/src/idempotent-bind.js
+++ b/src/idempotent-bind.js
@@ -43,6 +43,13 @@ function releaseBind(secondMap, thisArg) {
  * @template T
  */
 export function bind(target, thisArg) {
+    // support for `bind.call(func, this);`
+    // see https://github.com/azu/idempotent-bind/pull/1
+    if (this !== undefined) {
+        target = this;
+        thisArg = target;
+    }
+
     var secondMap = map.get(target);
     // need to save the bound function into WeakMp.
     if (thisArg == null) {
@@ -65,6 +72,11 @@ export function bind(target, thisArg) {
  * @template T
  */
 export function unbind(target, thisArg) {
+    if (this !== undefined) {
+        target = this;
+        thisArg = target;
+    }
+
     if (typeof target !== "function") {
         throw new Error("target must be function.");
     }

--- a/test/idempotent-bind-test.js
+++ b/test/idempotent-bind-test.js
@@ -19,6 +19,12 @@ describe("idempotent-bind", function () {
             };
             assert(bind(f, null) === bind(f, null));
         });
+
+        it("supports implicit `target` from callee's `this`", function () {
+            var f = function () {
+            };
+            assert(bind.call(f, this) === bind.call(f, this));
+        });
     });
     describe("#unbind", function () {
         it("should release binding", function () {
@@ -40,6 +46,13 @@ describe("idempotent-bind", function () {
             };
             var g = bind(f, null);
             assert(g === unbind(f, null));
+        });
+        it("should release binding for implicit `target`", function () {
+            var f = function () {
+            };
+            var g = bind.call(f, this);
+            unbind.call(f, this);
+            assert(g !== bind.call(f, this));
         });
     });
 });


### PR DESCRIPTION
The [function-bind operator is a proposed addition](https://github.com/zenparsing/es-function-bind) to JavaScript that is supported by Babel and is a great use case for a utility like this.

``` js
func::bind(this);
// is functionally equivalent to
bind.call(func, this);
```
